### PR TITLE
updated variant calling with new clair3 updated syntax which includes…

### DIFF
--- a/analysis/mips_to_nanopore.yaml
+++ b/analysis/mips_to_nanopore.yaml
@@ -1,6 +1,8 @@
-fastq_dir: /nfs/jbailey5/baileyweb/gtollefs/mips_to_nanopore_gt/240215_MtoN_P2/output/dorado_output/demuxed_fastq/fastq
-output_dir: /nfs/jbailey5/baileyweb/gtollefs/mips_to_nanopore_gt/240215_MtoN_P2/dorado_pipeline_output
+fastq_dir: /nfs/jbailey5/baileyweb/gtollefs/k13_hap/demuxing/072125_nanopore_seq_run
+output_dir: /nfs/jbailey5/baileyweb/gtollefs/k13_hap/alignment/output_alignment_072125
 project_resources: /nfs/jbailey5/baileyweb/gtollefs/mips_to_nanopore_gt/bams_to_vcf/resources # neevas rwandas samples are DR23KE. I prepared targets.vcf.gz for DR23KE and put in resources folder. Original 9.41 pipeline used DR23K targets.vcf.gz
 genome_directory: /nfs/jbailey5/baileyweb/bailey_share/resources/MIP_species_resources/pf/Pf_3D7/genomes
 clair3_sif_path: /nfs/jbailey5/baileyweb/asimkin/aapter_test/run_230508_mipstoNanopore_P2/bam_to_vcf/clair3_latest.sif
 src_path: /nfs/jbailey5/baileyweb/gtollefs/mips_to_nanopore_gt/nano_mamp_pipes/src # directory for storing all .py scripts called from any of the smks in the pipeline.
+amplicon_targets: /nfs/jbailey5/baileyweb/gtollefs/k13_hap/ordered_3kb_k13_hap_amplicons.multiplex00.bed
+#sample_metadata: /nfs/jbailey5/baileyweb/gtollefs/k13_hap/alignment/sample_metadata.csv

--- a/analysis/mips_to_nanopore_alignment.smk
+++ b/analysis/mips_to_nanopore_alignment.smk
@@ -17,7 +17,7 @@ rule all:
     input:
         sorted_bams=expand(config["output_dir"]+'/mapping/bam_files/{sample}.sorted.bam', sample=get_samples()),
         bam_index=expand(config["output_dir"]+'/mapping/bam_files/{sample}.sorted.bam.bai', sample=get_samples()),
-        bams_with_target_coverage_list=config['output_dir'] + "/samples_for_targeted_calling/bam_with_coverage.txt"
+        coverage_table=config['output_dir'] + "/coverage_analysis/amplicon_coverage_table.tsv"
 
 rule make_sam:
 	"""
@@ -40,7 +40,7 @@ rule make_bam:
 	output:
 		sample_bam=temp(config["output_dir"]+'/mapping/bam_files/{sample}.bam')
 	shell:
-		'samtools view -b -o {output.sample_bam} {input.sample_sam}'
+		'module load samtools && samtools view -b -o {output.sample_bam} {input.sample_sam}'
 
 rule sort_bam:
 	"""
@@ -51,7 +51,7 @@ rule sort_bam:
 	output:
 		sorted_bam=config["output_dir"]+'/mapping/bam_files/{sample}.sorted.bam'
 	shell:
-		'samtools sort -o {output.sorted_bam} {input.sample_bam_to_sort}'
+		'module load samtools && samtools sort -o {output.sorted_bam} {input.sample_bam_to_sort}'
 
 rule index_bam:
 	"""
@@ -62,18 +62,51 @@ rule index_bam:
 	output:
 		bam_index=config["output_dir"]+'/mapping/bam_files/{sample}.sorted.bam.bai'
 	shell:
-		'samtools index {input.sorted_bam}'
+		'module load samtools && samtools index {input.sorted_bam}'
 
-rule check_bam_coverage:
+rule check_amplicon_coverage:
     input:
-        bam_files=expand(config["output_dir"] + '/mapping/bam_files/{sample}.sorted.bam', sample=get_samples())
+        bam_files=expand(config["output_dir"] + '/mapping/bam_files/{sample}.sorted.bam', sample=get_samples()),
+        bam_indices=expand(config["output_dir"] + '/mapping/bam_files/{sample}.sorted.bam.bai', sample=get_samples()),
+        amplicon_targets=config["amplicon_targets"]
     output:
-        bams_with_target_coverage_list=config['output_dir'] + "/samples_for_targeted_calling/bam_with_coverage.txt"
+        coverage_table=config['output_dir'] + "/coverage_analysis/amplicon_coverage_table.tsv"
     params:
-        out_dir=config["output_dir"],
-        resource_dir=config["project_resources"],
-        src_directory=config["src_path"]
+        output_dir=config["output_dir"] + "/coverage_analysis"
     shell:
         """
-        sbatch --export=ALL {params.src_directory}/check_bams_for_target_reads.sh {params.out_dir} {params.resource_dir}
+        module load samtools && \
+        mkdir -p {params.output_dir} && \
+        echo -e "Sample\tAmplicon\tChrom\tStart\tEnd\tReads_Mapped\tMean_Depth\tMedian_Depth" > {output.coverage_table} && \
+        for bam in {input.bam_files}; do
+            sample=$(basename $bam .sorted.bam)
+            while read chrom start end amplicon; do
+                # Create temporary filtered BAM with reads >= 2300bp
+                temp_bam="/tmp/${{sample}}_${{amplicon}}_filtered.bam"
+                samtools view -h $bam "$chrom:$start-$end" | awk 'substr($1,1,1)=="@" || length($10) >= 2300' | samtools view -b > $temp_bam
+                samtools index $temp_bam
+                
+                # Count reads and calculate mean and median depth from filtered BAM
+                reads=$(samtools view -c $temp_bam "$chrom:$start-$end")
+                depth_stats=$(samtools depth -r "$chrom:$start-$end" $temp_bam | awk '{{depths[NR]=$3; sum+=$3}} END {{
+                    if(NR==0) {{
+                        print "0\t0"
+                    }} else {{
+                        mean = sum/NR
+                        asort(depths)
+                        if(NR%2==1) {{
+                            median = depths[(NR+1)/2]
+                        }} else {{
+                            median = (depths[NR/2] + depths[NR/2+1])/2
+                        }}
+                        print mean "\t" median
+                    }}
+                }}')
+                
+                echo -e "$sample\t$amplicon\t$chrom\t$start\t$end\t$reads\t$depth_stats" >> {output.coverage_table}
+                
+                # Clean up temporary files
+                rm -f $temp_bam $temp_bam.bai
+            done < {input.amplicon_targets}
+        done
         """

--- a/analysis/nanopore_variant_calling.smk
+++ b/analysis/nanopore_variant_calling.smk
@@ -1,0 +1,109 @@
+configfile: 'mips_to_nanopore.yaml'
+
+import os
+import glob
+
+# Get all sample names
+def get_samples():
+    fastq_files = glob.glob(os.path.join(config['fastq_dir'], '*.fastq.gz'))
+    sample_names = [
+        os.path.basename(f).replace('.fastq.gz', '') for f in fastq_files
+        if 'Undetermined' not in f and 'NTC' not in os.path.basename(f)
+    ]
+    return sample_names
+
+# Rule all to check final files
+rule all:
+    input:
+        finished_gvcf=config['output_dir']+'/variant_calling/merged_multisample.gvcf.gz',
+        finished_vcf=config['output_dir']+'/variant_calling/merged_multisample.vcf.gz'
+
+# Run Clair3 variant calling for each sample
+rule run_clair3_raw:
+    input:
+        bam=config["output_dir"]+'/mapping/bam_files/{sample}.sorted.bam',
+        REF=config['genome_directory']+'/genome.fa',
+        sif_path=config["clair3_sif_path"]
+    output:
+        vcf=config["output_dir"]+'/variant_calling/{sample}_raw/merge_output.vcf.gz',
+        gvcf=config["output_dir"]+'/variant_calling/{sample}_raw/merge_output.gvcf.gz'
+    params:
+        INPUT_DIR=config["output_dir"]+'/mapping/bam_files',
+        OUTPUT_DIR=config["output_dir"]+'/variant_calling/{sample}_raw',
+        GENOME_DIR=config['genome_directory'],
+        MODEL_NAME='r1041_e82_400bps_sup_v430_bacteria_finetuned',
+        THREADS=4
+    shell:
+        '''
+        echo 'Processing sample: {wildcards.sample}'
+        singularity exec \
+            -B {params.INPUT_DIR} \
+            -B {params.OUTPUT_DIR} \
+            -B {params.GENOME_DIR} \
+            {input.sif_path} \
+            /opt/bin/run_clair3.sh \
+            --bam_fn={input.bam} \
+            --ref_fn={input.REF} \
+            --model_path=/opt/models/{params.MODEL_NAME} \
+            --output={params.OUTPUT_DIR} \
+            --threads={params.THREADS} \
+            --platform=ont \
+            --include_all_ctgs \
+            --no_phasing_for_fa \
+            --sample_name={wildcards.sample} \
+            --gvcf \
+            --snp_min_af=0.001 \
+            --indel_min_af=0.001 \
+            --print_ref_calls
+        '''
+
+# Index GVCFs and VCFs
+rule index_gvcf:
+    input:
+        gvcf=config["output_dir"]+'/variant_calling/{sample}_raw/merge_output.gvcf.gz'
+    output:
+        gvcf_index=config["output_dir"]+'/variant_calling/{sample}_raw/merge_output.gvcf.gz.csi'
+    shell:
+        '''
+        module load bcftools;
+        bcftools index {input.gvcf}
+        '''
+
+rule index_vcf:
+    input:
+        vcf=config["output_dir"]+'/variant_calling/{sample}_raw/merge_output.vcf.gz'
+    output:
+        vcf_index=config["output_dir"]+'/variant_calling/{sample}_raw/merge_output.vcf.gz.csi'
+    shell:
+        '''
+        module load bcftools;
+        bcftools index {input.vcf}
+        '''
+
+# Merge GVCFs
+rule merge_gvcfs:
+    input:
+        gvcf_indices=expand(config["output_dir"]+'/variant_calling/{sample}_raw/merge_output.gvcf.gz.csi', sample=get_samples())
+    output:
+        merged_gvcf=config["output_dir"]+'/variant_calling/merged_multisample.gvcf.gz'
+    shell:
+        '''
+        module load bcftools;
+        bcftools merge \
+            {config[output_dir]}/variant_calling/*_raw/merge_output.gvcf.gz \
+            --force-samples -O z -o {output.merged_gvcf}
+        '''
+
+# Merge VCFs
+rule merge_vcfs:
+    input:
+        vcf_indices=expand(config["output_dir"]+'/variant_calling/{sample}_raw/merge_output.vcf.gz.csi', sample=get_samples())
+    output:
+        merged_vcf=config["output_dir"]+'/variant_calling/merged_multisample.vcf.gz'
+    shell:
+        '''
+        module load bcftools;
+        bcftools merge \
+            {config[output_dir]}/variant_calling/*_raw/merge_output.vcf.gz \
+            --force-samples -O z -o {output.merged_vcf}
+        '''


### PR DESCRIPTION
… per base calls for all sites in gvcf, replacing need for targetted calling and merging targets vcf with genomewide vcf. Additionally, this pipeline currently accepts a bed file for computing amplicon coverage after alignment but can be easily modified to make this optional. Next steps are to make a --amplicon toggle in the yaml to turn on amplicon coverage calculation accepting a bed file.